### PR TITLE
Refactor: Extract re-used metadata into separate file

### DIFF
--- a/src/app/(homePage)/head.tsx
+++ b/src/app/(homePage)/head.tsx
@@ -1,32 +1,17 @@
+import HeadCommonElements from "@components/head/HeadCommonElements";
+import HeadIcons from "@components/head/HeadIcons";
+
 export default function Head() {
   return (
     <>
       <title>Vincit Table Tennis</title>
       <meta
-        name="viewport"
-        content="minimum-scale=1, initial-scale=1, width=device-width"
-      />
-      <meta
         name="apple-mobile-web-app-title"
         content="Home • Vincit Table Tennis"
       />
-      <link rel="apple-touch-icon" href="touch-icon-ipad-retina.png"></link>
-      {/* Apple iPhone High Resolution */}
-      <link
-        rel="apple-touch-icon"
-        sizes="180x180"
-        href="touch-icon-iphone-retina.png"
-      />
-      {/* Apple iPad High Resolution */}
-      <link
-        rel="apple-touch-icon"
-        sizes="167x167"
-        href="touch-icon-ipad-retina.png"
-      />
-      {/* Android Devices High Resolution */}
-      <link rel="icon" sizes="192x192" href="touch-icon-hd.png" />
-      {/* Android Devices Normal Resolution */}
-      <link rel="icon" sizes="128x128" href="touch-icon.png" />
+
+      <HeadCommonElements />
+      <HeadIcons />
     </>
   );
 }

--- a/src/app/(webApp)/game/head.tsx
+++ b/src/app/(webApp)/game/head.tsx
@@ -1,30 +1,15 @@
+import HeadCommonElements from "@components/head/HeadCommonElements";
+import HeadIcons from "@components/head/HeadIcons";
+
 export default function Head() {
   return (
     <>
       <title>Game • Vincit Table Tennis</title>
-      <meta
-        name="viewport"
-        content="minimum-scale=1, initial-scale=1, width=device-width"
-      />
       <meta name="apple-mobile-web-app-title" content="Log Game" />
       <meta name="apple-mobile-web-app-capable" content="yes" />
-      <link rel="apple-touch-icon" href="touch-icon-ipad-retina.png"></link>
-      {/* Apple iPhone High Resolution */}
-      <link
-        rel="apple-touch-icon"
-        sizes="180x180"
-        href="touch-icon-iphone-retina.png"
-      />
-      {/* Apple iPad High Resolution */}
-      <link
-        rel="apple-touch-icon"
-        sizes="167x167"
-        href="touch-icon-ipad-retina.png"
-      />
-      {/* Android Devices High Resolution */}
-      <link rel="icon" sizes="192x192" href="touch-icon-hd.png" />
-      {/* Android Devices Normal Resolution */}
-      <link rel="icon" sizes="128x128" href="touch-icon.png" />
+
+      <HeadCommonElements />
+      <HeadIcons />
     </>
   );
 }

--- a/src/app/(webApp)/register/head.tsx
+++ b/src/app/(webApp)/register/head.tsx
@@ -1,29 +1,14 @@
+import HeadCommonElements from "@components/head/HeadCommonElements";
+import HeadIcons from "@components/head/HeadIcons";
+
 export default function Head() {
   return (
     <>
       <title>Register • Vincit Table Tennis</title>
-      <meta
-        name="viewport"
-        content="minimum-scale=1, initial-scale=1, width=device-width"
-      />
       <meta name="apple-mobile-web-app-title" content="Register" />
-      <link rel="apple-touch-icon" href="touch-icon-ipad-retina.png"></link>
-      {/* Apple iPhone High Resolution */}
-      <link
-        rel="apple-touch-icon"
-        sizes="180x180"
-        href="touch-icon-iphone-retina.png"
-      />
-      {/* Apple iPad High Resolution */}
-      <link
-        rel="apple-touch-icon"
-        sizes="167x167"
-        href="touch-icon-ipad-retina.png"
-      />
-      {/* Android Devices High Resolution */}
-      <link rel="icon" sizes="192x192" href="touch-icon-hd.png" />
-      {/* Android Devices Normal Resolution */}
-      <link rel="icon" sizes="128x128" href="touch-icon.png" />
+
+      <HeadCommonElements />
+      <HeadIcons />
     </>
   );
 }

--- a/src/app/(webApp)/stats/head.tsx
+++ b/src/app/(webApp)/stats/head.tsx
@@ -1,29 +1,14 @@
+import HeadCommonElements from "@components/head/HeadCommonElements";
+import HeadIcons from "@components/head/HeadIcons";
+
 export default function Head() {
   return (
     <>
       <title>Stats • Vincit Table Tennis</title>
-      <meta
-        name="viewport"
-        content="minimum-scale=1, initial-scale=1, width=device-width"
-      />
       <meta name="apple-mobile-web-app-title" content="Stat Viewer" />
-      <link rel="apple-touch-icon" href="touch-icon-ipad-retina.png"></link>
-      {/* Apple iPhone High Resolution */}
-      <link
-        rel="apple-touch-icon"
-        sizes="180x180"
-        href="touch-icon-iphone-retina.png"
-      />
-      {/* Apple iPad High Resolution */}
-      <link
-        rel="apple-touch-icon"
-        sizes="167x167"
-        href="touch-icon-ipad-retina.png"
-      />
-      {/* Android Devices High Resolution */}
-      <link rel="icon" sizes="192x192" href="touch-icon-hd.png" />
-      {/* Android Devices Normal Resolution */}
-      <link rel="icon" sizes="128x128" href="touch-icon.png" />
+
+      <HeadCommonElements />
+      <HeadIcons />
     </>
   );
 }

--- a/src/components/head/HeadCommonElements.tsx
+++ b/src/components/head/HeadCommonElements.tsx
@@ -1,0 +1,10 @@
+export default function HeadCommonElements() {
+  return (
+    <>
+      <meta
+        name="viewport"
+        content="minimum-scale=1, initial-scale=1, width=device-width"
+      />
+    </>
+  );
+}

--- a/src/components/head/HeadIcons.tsx
+++ b/src/components/head/HeadIcons.tsx
@@ -1,0 +1,23 @@
+export default function HeadIcons() {
+  return (
+    <>
+      <link rel="apple-touch-icon" href="touch-icon-ipad-retina.png"></link>
+      {/* Apple iPhone High Resolution */}
+      <link
+        rel="apple-touch-icon"
+        sizes="180x180"
+        href="touch-icon-iphone-retina.png"
+      />
+      {/* Apple iPad High Resolution */}
+      <link
+        rel="apple-touch-icon"
+        sizes="167x167"
+        href="touch-icon-ipad-retina.png"
+      />
+      {/* Android Devices High Resolution */}
+      <link rel="icon" sizes="192x192" href="touch-icon-hd.png" />
+      {/* Android Devices Normal Resolution */}
+      <link rel="icon" sizes="128x128" href="touch-icon.png" />
+    </>
+  );
+}


### PR DESCRIPTION
resolves #15 

# Changes

- Code-split `viewport` `meta` element from all `head.tsx` files into a single component: `HeadCommonElements`.
- Code-split all app icon links from `head.tsx` to `HeadIcons`